### PR TITLE
FIXED: Semicolon syntax error

### DIFF
--- a/examples/getInfo.js
+++ b/examples/getInfo.js
@@ -9,7 +9,7 @@ wa.searchAnime(imgPath)
   .then(searchResult => {
     return wa.getInfo(searchResult[0]['anilist_id']);
   })
-  .then(aniInfo => console.log(aniInfo));
+  .then(aniInfo => console.log(aniInfo))
   .catch(err => {
     console.error(err);
   });


### PR DESCRIPTION
The semicolon on line 12 did not allow the `catch()` method to execute causing syntax error.